### PR TITLE
Fix embed.FS path handling for Windows compatibility

### DIFF
--- a/src/assets/bundled.go
+++ b/src/assets/bundled.go
@@ -2,7 +2,7 @@ package assets
 
 import (
 	"embed"
-	"path/filepath"
+	"path"
 
 	"fyne.io/fyne/v2"
 )
@@ -25,7 +25,7 @@ func Resource(path string) fyne.Resource {
 
 // Name はリソースのファイル名を返す
 func (r *resource) Name() string {
-	return filepath.Base(r.path)
+	return path.Base(r.path)
 }
 
 // Content はリソースの内容を返す

--- a/src/assets/i18n.go
+++ b/src/assets/i18n.go
@@ -3,7 +3,7 @@ package assets
 import (
 	"embed"
 	"encoding/json"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"fyne.io/fyne/v2/lang"
@@ -39,7 +39,7 @@ func AvailableLocales() []Locale {
 
 		// 言語ファイルから言語名を取得
 		name := code
-		localeFile := filepath.Join("locales", fileName)
+		localeFile := path.Join("locales", fileName)
 		if data, err := embeddedLocales.ReadFile(localeFile); err == nil {
 			var translations map[string]string
 			if err := json.Unmarshal(data, &translations); err == nil {
@@ -74,7 +74,7 @@ func InitI18nWithLocale(locale string) error {
 	}
 
 	// 指定されたロケールの翻訳を読み込む
-	localeFile := filepath.Join("locales", locale+".json")
+	localeFile := path.Join("locales", locale+".json")
 	data, err := embeddedLocales.ReadFile(localeFile)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- Replace `path/filepath` with `path` package in `src/assets/i18n.go` and `src/assets/bundled.go` for `embed.FS` path operations
- `embed.FS` follows the `io/fs` spec which requires forward slashes, but `filepath.Join`/`filepath.Base` use OS-dependent separators (backslash on Windows)
- On Windows, this caused `AvailableLocales()` to return locale codes instead of display names, and `InitI18nWithLocale()` to fail entirely

## Changes
- `src/assets/i18n.go`: `filepath.Join` → `path.Join` (2 locations) + import update
- `src/assets/bundled.go`: `filepath.Base` → `path.Base` (1 location) + import update

## Test plan
- [x] `just lint` passes
- [x] `just test` passes
- [x] `path.Join("locales", "en.json")` always produces `"locales/en.json"` regardless of OS

Closes #1