### PR TITLE
Fix entry menu to appear near the clicked button

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -1,6 +1,8 @@
 {
     "language.name": "English",
     "app.title": "Winticator",
+    "Yes": "Yes",
+    "No": "No",
     "toolbar.totp": "TOTP",
     "toolbar.setting": "Settings",
     "toolbar.info": "Info",
@@ -25,8 +27,6 @@
     "dialog.cancel": "Cancel",
     "dialog.add": "Add",
     "dialog.close": "Close",
-    "dialog.yes": "Yes",
-    "dialog.no": "No",
     "setting.header": "Settings",
     "setting.theme": "Theme:",
     "setting.theme.light": "Light",

--- a/src/assets/locales/ja.json
+++ b/src/assets/locales/ja.json
@@ -1,6 +1,8 @@
 {
     "language.name": "日本語",
     "app.title": "Winticator",
+    "Yes": "はい",
+    "No": "いいえ",
     "toolbar.totp": "TOTP",
     "toolbar.setting": "設定",
     "toolbar.info": "情報",
@@ -25,8 +27,6 @@
     "dialog.cancel": "キャンセル",
     "dialog.add": "追加",
     "dialog.close": "閉じる",
-    "dialog.yes": "はい",
-    "dialog.no": "いいえ",
     "setting.header": "設定",
     "setting.theme": "テーマ:",
     "setting.theme.light": "ライト",

--- a/src/ui/totplist.go
+++ b/src/ui/totplist.go
@@ -160,7 +160,7 @@ func (v *totpListView) updateListItem(id widget.ListItemID, item fyne.CanvasObje
 
 	// メニューボタン
 	menuButton.OnTapped = func() {
-		v.showEntryMenu(entryCopy)
+		v.showEntryMenu(entryCopy, menuButton)
 	}
 }
 
@@ -211,7 +211,7 @@ func (v *totpListView) copyCode(entry *totpstore.Entry) {
 }
 
 // showEntryMenu はエントリのメニューを表示する
-func (v *totpListView) showEntryMenu(entry *totpstore.Entry) {
+func (v *totpListView) showEntryMenu(entry *totpstore.Entry, anchor fyne.CanvasObject) {
 	items := []*fyne.MenuItem{
 		fyne.NewMenuItem(lang.L("totp.menu.edit"), func() {
 			v.showEditDialog(entry)
@@ -227,7 +227,8 @@ func (v *totpListView) showEntryMenu(entry *totpstore.Entry) {
 
 	menu := fyne.NewMenu("", items...)
 	popup := widget.NewPopUpMenu(menu, v.app.mainWindow.Canvas())
-	popup.ShowAtPosition(fyne.CurrentApp().Driver().AbsolutePositionForObject(v.list))
+	rel := fyne.NewPos(anchor.Size().Width/2-popup.Size().Width, anchor.Size().Height/2)
+	popup.ShowAtRelativePosition(rel, anchor)
 }
 
 // showEditDialog は編集ダイアログを表示する


### PR DESCRIPTION
## Summary

- Fix the entry menu popup appearing at the top-left of the list regardless of which menu button was clicked
- Use `ShowAtRelativePosition` with the menu button as anchor so the popup appears near the tapped button
- Normalize Yes/No locale keys to match Fyne's built-in dialog button labels

## Test plan

- [x] `just lint` passes
- [x] `just test` passes
- [x] After building, click each entry's menu button and verify the menu appears near the button