### PR TITLE
Refactor: split totplist.go into list/item files

### DIFF
--- a/src/ui/totplist.go
+++ b/src/ui/totplist.go
@@ -3,18 +3,13 @@ package ui
 import (
 	"errors"
 	"fmt"
-	"image/color"
 	"time"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/lang"
-	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
-	"github.com/nktmys/winticator/src/ui/custom"
-	"github.com/nktmys/winticator/src/ui/custom/components"
 	"github.com/nktmys/winticator/src/usecase/qrscanner"
 	"github.com/nktmys/winticator/src/usecase/totpstore"
 )
@@ -72,98 +67,6 @@ type totpListView struct {
 	container *fyne.Container
 }
 
-// createListItem はリストアイテムのテンプレートを作成する
-func (v *totpListView) createListItem() fyne.CanvasObject {
-	// 表示名（Account または Issuer）
-	displayNameLabel := widget.NewLabel("DisplayName")
-
-	// TOTPコード（青色・大きいフォント・タップ可能）
-	codeText := components.NewTappableText("000 000",
-		custom.ColorPrimaryBlue, 28)
-
-	// 左パディング用のスペーサーを追加（widget.LabelのInnerPaddingに合わせる）
-	codePadding := canvas.NewRectangle(color.Transparent)
-	codePadding.SetMinSize(fyne.NewSize(theme.InnerPadding(), 0))
-	paddedCode := container.NewHBox(codePadding, codeText)
-
-	// 円形プログレス
-	circularProgress := components.NewCircularProgress(32)
-
-	// メニューボタン
-	menuButton := widget.NewButtonWithIcon("", theme.MoreHorizontalIcon(), nil)
-
-	// 左側: 表示名 + コード（パディング付き）
-	leftContent := container.NewVBox(displayNameLabel, paddedCode)
-
-	// 右側: 円形プログレス + メニュー
-	rightContent := container.NewHBox(circularProgress, menuButton)
-
-	return container.NewBorder(nil, nil, leftContent, rightContent)
-}
-
-// updateListItem はリストアイテムを更新する
-func (v *totpListView) updateListItem(id widget.ListItemID, item fyne.CanvasObject) {
-	if id >= len(v.entries) {
-		return
-	}
-
-	entry := v.entries[id]
-	border := item.(*fyne.Container)
-
-	// 左側のコンテンツを取得
-	leftContent := border.Objects[0].(*fyne.Container)
-	displayNameLabel := leftContent.Objects[0].(*widget.Label)
-	paddedCode := leftContent.Objects[1].(*fyne.Container)
-	codeText := paddedCode.Objects[1].(*components.TappableText)
-
-	// 右側のコンテンツを取得
-	rightBox := border.Objects[1].(*fyne.Container)
-	circularProgress := rightBox.Objects[0].(*components.CircularProgress)
-	menuButton := rightBox.Objects[1].(*widget.Button)
-
-	// 表示名を設定
-	displayNameLabel.SetText(entry.DisplayName())
-
-	// TOTPコードを生成
-	code, err := entry.TOTP()
-	if err != nil {
-		codeText.SetText("------")
-	} else {
-		// 3桁ごとにスペースを挿入
-		if len(code) == 6 {
-			code = code[:3] + " " + code[3:]
-		}
-		codeText.SetText(code)
-	}
-
-	// 残り時間を設定
-	remaining := entry.RemainingSeconds()
-	circularProgress.Max = float64(entry.Period)
-	circularProgress.SetValue(float64(remaining))
-
-	// 残り5秒未満で赤色に変更
-	if remaining < 5 {
-		warningColor := custom.ColorPrimaryRed
-		codeText.SetColor(warningColor)
-		circularProgress.SetColor(warningColor)
-	} else {
-		normalColor := custom.ColorPrimaryBlue
-		codeText.SetColor(normalColor)
-		circularProgress.SetColor(normalColor)
-	}
-
-	// コードクリックでコピー（entryをキャプチャ）
-	entryCopy := entry
-	codeText.OnTapped = func() {
-		v.copyCode(entryCopy)
-	}
-
-	// メニューボタン
-	menuButton.OnTapped = func() {
-		v.showEntryMenu(entryCopy, menuButton)
-	}
-}
-
 // updateEmptyState は空の状態表示を更新する
 func (v *totpListView) updateEmptyState(emptyLabel *widget.Label) {
 	if len(v.entries) == 0 {
@@ -193,131 +96,17 @@ func (v *totpListView) startRefresh() {
 	}()
 }
 
-// copyCode はTOTPコードをクリップボードにコピーする
-func (v *totpListView) copyCode(entry *totpstore.Entry) {
-	code, err := entry.TOTP()
-	if err != nil {
-		return
+// refreshEntries はエントリリストを更新する
+func (v *totpListView) refreshEntries() {
+	v.entries = v.store.GetAll()
+	v.list.Refresh()
+
+	// 空状態の更新
+	if len(v.container.Objects) >= 2 {
+		if emptyLabel, ok := v.container.Objects[1].(*widget.Label); ok {
+			v.updateEmptyState(emptyLabel)
+		}
 	}
-
-	v.app.fyneApp.Clipboard().SetContent(code)
-
-	// コピー完了通知
-	dialog.ShowInformation(
-		lang.L("totp.copied.title"),
-		lang.L("totp.copied.message", M{"displayName": entry.DisplayName()}),
-		v.app.mainWindow,
-	)
-}
-
-// showEntryMenu はエントリのメニューを表示する
-func (v *totpListView) showEntryMenu(entry *totpstore.Entry, anchor fyne.CanvasObject) {
-	items := []*fyne.MenuItem{
-		fyne.NewMenuItem(lang.L("totp.menu.edit"), func() {
-			v.showEditDialog(entry)
-		}),
-		fyne.NewMenuItem(lang.L("totp.menu.showqr"), func() {
-			v.showQRCode(entry)
-		}),
-		fyne.NewMenuItemSeparator(),
-		fyne.NewMenuItem(lang.L("totp.menu.delete"), func() {
-			v.confirmDelete(entry)
-		}),
-	}
-
-	menu := fyne.NewMenu("", items...)
-	popup := widget.NewPopUpMenu(menu, v.app.mainWindow.Canvas())
-	rel := fyne.NewPos(anchor.Size().Width/2-popup.Size().Width, anchor.Size().Height/2)
-	popup.ShowAtRelativePosition(rel, anchor)
-}
-
-// showEditDialog は編集ダイアログを表示する
-func (v *totpListView) showEditDialog(entry *totpstore.Entry) {
-	issuerEntry := widget.NewEntry()
-	issuerEntry.SetText(entry.Issuer)
-
-	accountEntry := widget.NewEntry()
-	accountEntry.SetText(entry.Account)
-
-	form := dialog.NewForm(
-		lang.L("totp.edit.title"),
-		lang.L("dialog.save"),
-		lang.L("dialog.cancel"),
-		[]*widget.FormItem{
-			widget.NewFormItem(lang.L("totp.edit.issuer"), issuerEntry),
-			widget.NewFormItem(lang.L("totp.edit.account"), accountEntry),
-		},
-		func(confirmed bool) {
-			if !confirmed {
-				return
-			}
-			entry.Issuer = issuerEntry.Text
-			entry.Account = accountEntry.Text
-			if err := v.store.Update(entry); err != nil {
-				dialog.ShowError(err, v.app.mainWindow)
-				return
-			}
-			if err := v.store.Save(); err != nil {
-				dialog.ShowError(err, v.app.mainWindow)
-				return
-			}
-			v.list.Refresh()
-		},
-		v.app.mainWindow,
-	)
-	form.Resize(fyne.NewSize(400, 200))
-	form.Show()
-}
-
-// showQRCode はQRコードを表示する
-func (v *totpListView) showQRCode(entry *totpstore.Entry) {
-	uri := entry.ToOTPAuthURI()
-
-	// QRコード生成
-	qr, err := generateQRCodeImage(uri)
-	if err != nil {
-		dialog.ShowError(err, v.app.mainWindow)
-		return
-	}
-
-	img := canvas.NewImageFromImage(qr)
-	img.FillMode = canvas.ImageFillContain
-	img.SetMinSize(fyne.NewSize(200, 200))
-
-	content := container.NewVBox(
-		img,
-		widget.NewLabel(entry.DisplayName()),
-	)
-
-	dialog.ShowCustom(
-		lang.L("totp.qr.title"),
-		lang.L("dialog.close"),
-		content,
-		v.app.mainWindow,
-	)
-}
-
-// confirmDelete は削除確認ダイアログを表示する
-func (v *totpListView) confirmDelete(entry *totpstore.Entry) {
-	dialog.ShowConfirm(
-		lang.L("totp.delete.title"),
-		lang.L("totp.delete.message", M{"displayName": entry.DisplayName()}),
-		func(confirmed bool) {
-			if !confirmed {
-				return
-			}
-			if err := v.store.Delete(entry.ID); err != nil {
-				dialog.ShowError(err, v.app.mainWindow)
-				return
-			}
-			if err := v.store.Save(); err != nil {
-				dialog.ShowError(err, v.app.mainWindow)
-				return
-			}
-			v.refreshEntries()
-		},
-		v.app.mainWindow,
-	)
 }
 
 // scanQRCode はQRコードをスキャンしてエントリを追加する
@@ -364,6 +153,22 @@ func (v *totpListView) scanQRCode() {
 
 // showAddConfirmDialog は追加確認ダイアログを表示する
 func (v *totpListView) showAddConfirmDialog(entry *totpstore.Entry) {
+	v.showEntryFormDialog(
+		entry,
+		lang.L("totp.add.title"),
+		lang.L("dialog.add"),
+		func(e *totpstore.Entry) error {
+			return v.store.Add(e)
+		},
+	)
+}
+
+// showEntryFormDialog はエントリのフォームダイアログを表示する共通ヘルパー
+func (v *totpListView) showEntryFormDialog(
+	entry *totpstore.Entry,
+	title, confirmLabel string,
+	onSave func(*totpstore.Entry) error,
+) {
 	issuerEntry := widget.NewEntry()
 	issuerEntry.SetText(entry.Issuer)
 
@@ -371,8 +176,8 @@ func (v *totpListView) showAddConfirmDialog(entry *totpstore.Entry) {
 	accountEntry.SetText(entry.Account)
 
 	form := dialog.NewForm(
-		lang.L("totp.add.title"),
-		lang.L("dialog.add"),
+		title,
+		confirmLabel,
 		lang.L("dialog.cancel"),
 		[]*widget.FormItem{
 			widget.NewFormItem(lang.L("totp.edit.issuer"), issuerEntry),
@@ -384,7 +189,7 @@ func (v *totpListView) showAddConfirmDialog(entry *totpstore.Entry) {
 			}
 			entry.Issuer = issuerEntry.Text
 			entry.Account = accountEntry.Text
-			if err := v.store.Add(entry); err != nil {
+			if err := onSave(entry); err != nil {
 				dialog.ShowError(err, v.app.mainWindow)
 				return
 			}
@@ -398,17 +203,4 @@ func (v *totpListView) showAddConfirmDialog(entry *totpstore.Entry) {
 	)
 	form.Resize(fyne.NewSize(400, 200))
 	form.Show()
-}
-
-// refreshEntries はエントリリストを更新する
-func (v *totpListView) refreshEntries() {
-	v.entries = v.store.GetAll()
-	v.list.Refresh()
-
-	// 空状態の更新
-	if len(v.container.Objects) >= 2 {
-		if emptyLabel, ok := v.container.Objects[1].(*widget.Label); ok {
-			v.updateEmptyState(emptyLabel)
-		}
-	}
 }

--- a/src/ui/totplist_item.go
+++ b/src/ui/totplist_item.go
@@ -1,0 +1,210 @@
+package ui
+
+import (
+	"image/color"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/lang"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+	"github.com/nktmys/winticator/src/ui/custom"
+	"github.com/nktmys/winticator/src/ui/custom/components"
+	"github.com/nktmys/winticator/src/usecase/qrscanner"
+	"github.com/nktmys/winticator/src/usecase/totpstore"
+)
+
+// createListItem はリストアイテムのテンプレートを作成する
+func (v *totpListView) createListItem() fyne.CanvasObject {
+	// 表示名（Account または Issuer）
+	displayNameLabel := widget.NewLabel("DisplayName")
+
+	// TOTPコード（青色・大きいフォント・タップ可能）
+	codeText := components.NewTappableText("000 000",
+		custom.ColorPrimaryBlue, 28)
+
+	// 左パディング用のスペーサーを追加（widget.LabelのInnerPaddingに合わせる）
+	codePadding := canvas.NewRectangle(color.Transparent)
+	codePadding.SetMinSize(fyne.NewSize(theme.InnerPadding(), 0))
+	paddedCode := container.NewHBox(codePadding, codeText)
+
+	// 円形プログレス
+	circularProgress := components.NewCircularProgress(32)
+
+	// メニューボタン
+	menuButton := widget.NewButtonWithIcon("", theme.MoreHorizontalIcon(), nil)
+
+	// 左側: 表示名 + コード（パディング付き）
+	leftContent := container.NewVBox(displayNameLabel, paddedCode)
+
+	// 右側: 円形プログレス + メニュー
+	rightContent := container.NewHBox(circularProgress, menuButton)
+
+	return container.NewBorder(nil, nil, leftContent, rightContent)
+}
+
+// updateListItem はリストアイテムを更新する
+func (v *totpListView) updateListItem(id widget.ListItemID, item fyne.CanvasObject) {
+	if id >= len(v.entries) {
+		return
+	}
+
+	entry := v.entries[id]
+	border := item.(*fyne.Container)
+
+	// 左側のコンテンツを取得
+	leftContent := border.Objects[0].(*fyne.Container)
+	displayNameLabel := leftContent.Objects[0].(*widget.Label)
+	paddedCode := leftContent.Objects[1].(*fyne.Container)
+	codeText := paddedCode.Objects[1].(*components.TappableText)
+
+	// 右側のコンテンツを取得
+	rightBox := border.Objects[1].(*fyne.Container)
+	circularProgress := rightBox.Objects[0].(*components.CircularProgress)
+	menuButton := rightBox.Objects[1].(*widget.Button)
+
+	// 表示名を設定
+	displayNameLabel.SetText(entry.DisplayName())
+
+	// TOTPコードを生成
+	code, err := entry.TOTP()
+	if err != nil {
+		codeText.SetText("------")
+	} else {
+		// 3桁ごとにスペースを挿入
+		if len(code) == 6 {
+			code = code[:3] + " " + code[3:]
+		}
+		codeText.SetText(code)
+	}
+
+	// 残り時間を設定
+	remaining := entry.RemainingSeconds()
+	circularProgress.Max = float64(entry.Period)
+	circularProgress.SetValue(float64(remaining))
+
+	// 残り5秒未満で赤色に変更
+	if remaining < 5 {
+		warningColor := custom.ColorPrimaryRed
+		codeText.SetColor(warningColor)
+		circularProgress.SetColor(warningColor)
+	} else {
+		normalColor := custom.ColorPrimaryBlue
+		codeText.SetColor(normalColor)
+		circularProgress.SetColor(normalColor)
+	}
+
+	// コードクリックでコピー（entryをキャプチャ）
+	entryCopy := entry
+	codeText.OnTapped = func() {
+		v.copyCode(entryCopy)
+	}
+
+	// メニューボタン
+	menuButton.OnTapped = func() {
+		v.showEntryMenu(entryCopy, menuButton)
+	}
+}
+
+// copyCode はTOTPコードをクリップボードにコピーする
+func (v *totpListView) copyCode(entry *totpstore.Entry) {
+	code, err := entry.TOTP()
+	if err != nil {
+		return
+	}
+
+	v.app.fyneApp.Clipboard().SetContent(code)
+
+	// コピー完了通知
+	dialog.ShowInformation(
+		lang.L("totp.copied.title"),
+		lang.L("totp.copied.message", M{"displayName": entry.DisplayName()}),
+		v.app.mainWindow,
+	)
+}
+
+// showEntryMenu はエントリのメニューを表示する
+func (v *totpListView) showEntryMenu(entry *totpstore.Entry, anchor fyne.CanvasObject) {
+	items := []*fyne.MenuItem{
+		fyne.NewMenuItem(lang.L("totp.menu.edit"), func() {
+			v.showEditDialog(entry)
+		}),
+		fyne.NewMenuItem(lang.L("totp.menu.showqr"), func() {
+			v.showQRCode(entry)
+		}),
+		fyne.NewMenuItemSeparator(),
+		fyne.NewMenuItem(lang.L("totp.menu.delete"), func() {
+			v.confirmDelete(entry)
+		}),
+	}
+
+	menu := fyne.NewMenu("", items...)
+	popup := widget.NewPopUpMenu(menu, v.app.mainWindow.Canvas())
+	rel := fyne.NewPos(anchor.Size().Width/2-popup.Size().Width, anchor.Size().Height/2)
+	popup.ShowAtRelativePosition(rel, anchor)
+}
+
+// showEditDialog は編集ダイアログを表示する
+func (v *totpListView) showEditDialog(entry *totpstore.Entry) {
+	v.showEntryFormDialog(
+		entry,
+		lang.L("totp.edit.title"),
+		lang.L("dialog.save"),
+		func(e *totpstore.Entry) error {
+			return v.store.Update(e)
+		},
+	)
+}
+
+// showQRCode はQRコードを表示する
+func (v *totpListView) showQRCode(entry *totpstore.Entry) {
+	uri := entry.ToOTPAuthURI()
+
+	// QRコード生成
+	qr, err := qrscanner.GenerateQRCodeImage(uri)
+	if err != nil {
+		dialog.ShowError(err, v.app.mainWindow)
+		return
+	}
+
+	img := canvas.NewImageFromImage(qr)
+	img.FillMode = canvas.ImageFillContain
+	img.SetMinSize(fyne.NewSize(200, 200))
+
+	content := container.NewVBox(
+		img,
+		widget.NewLabel(entry.DisplayName()),
+	)
+
+	dialog.ShowCustom(
+		lang.L("totp.qr.title"),
+		lang.L("dialog.close"),
+		content,
+		v.app.mainWindow,
+	)
+}
+
+// confirmDelete は削除確認ダイアログを表示する
+func (v *totpListView) confirmDelete(entry *totpstore.Entry) {
+	dialog.ShowConfirm(
+		lang.L("totp.delete.title"),
+		lang.L("totp.delete.message", M{"displayName": entry.DisplayName()}),
+		func(confirmed bool) {
+			if !confirmed {
+				return
+			}
+			if err := v.store.Delete(entry.ID); err != nil {
+				dialog.ShowError(err, v.app.mainWindow)
+				return
+			}
+			if err := v.store.Save(); err != nil {
+				dialog.ShowError(err, v.app.mainWindow)
+				return
+			}
+			v.refreshEntries()
+		},
+		v.app.mainWindow,
+	)
+}

--- a/src/usecase/qrscanner/generater.go
+++ b/src/usecase/qrscanner/generater.go
@@ -1,4 +1,4 @@
-package ui
+package qrscanner
 
 import (
 	"image"
@@ -6,8 +6,8 @@ import (
 	qrcode "github.com/skip2/go-qrcode"
 )
 
-// generateQRCodeImage はURIからQRコード画像を生成する
-func generateQRCodeImage(uri string) (image.Image, error) {
+// GenerateQRCodeImage はURIからQRコード画像を生成する
+func GenerateQRCodeImage(uri string) (image.Image, error) {
 	qr, err := qrcode.New(uri, qrcode.Medium)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Split `src/ui/totplist.go` (411 lines) into two focused files by domain responsibility:
  - `totplist.go` (~175 lines) — list container management (struct, constructor, empty state, refresh, QR scan workflow, add dialog)
  - `totplist_item.go` (~210 lines) — individual item rendering & actions (create/update template, copy, menu, edit/QR/delete dialogs)
- Extract `showEntryFormDialog` as a shared helper to eliminate duplicated form dialog logic between `showEditDialog` and `showAddConfirmDialog`
- Move `generateQRCodeImage` from `ui/qrcode.go` to `qrscanner.GenerateQRCodeImage` (exported, closer to its domain)

## Test plan
- [x] `just lint` passes (gofmt, staticcheck)
- [x] `just test` passes (go test ./... -failfast)
- [x] `just build` passes
- [x] Manual verification: TOTP list displays correctly, item actions (copy, edit, QR, delete) work as before

Closes #7